### PR TITLE
Make space after "FAIL:" optional

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -45,7 +45,7 @@ export class UnityAdapter implements TestAdapter {
 	private testBuildTargetRegex: string = '$1';
 	private testExecutableRegex: string = '$1';
 
-	private readonly testResultString = ':(PASS|(FAIL: (.*)))';
+	private readonly testResultString = ':(PASS|(FAIL:\ ?(.*)))';
 	private buildProcess: child_process.ChildProcess | undefined;
 	private suiteProcess: child_process.ChildProcess | undefined;
 	private buildMutex: async_mutex.Mutex = new async_mutex.Mutex();


### PR DESCRIPTION
CMock may fail without a preceding space:

```
[...]\CMock\examples\temp_sensor\test\TestMain.c:14:testMainShouldCallExecutorInitAndContinueToCallExecutorRunUntilHalted:FAIL:Function Executor_Run.  Called fewer times than expected.
[...]\CMock\examples\temp_sensor\test\TestTemperatureFilter.c:37:testShouldResetAverageIfPassedInfinityOrInvalidValue:FAIL: Expected -inf Was nan
```

Unity tools deal with this just fine, but here the regex was to strict.

(Above output is reproducible by duplicating line 21 here: https://github.com/ThrowTheSwitch/CMock/blob/master/examples/temp_sensor/test/TestMain.c#L21 and running `rake` in the `temp_sensor` folder)